### PR TITLE
【リポジトリ検索】GitHubリポジトリの検索メソッドにasync-await版を追加

### DIFF
--- a/iOSEngineerCodeCheck/Entity/APIClient.swift
+++ b/iOSEngineerCodeCheck/Entity/APIClient.swift
@@ -16,9 +16,7 @@ protocol APIClientProtocol {
     func sendRequest<T: GitHubAPIRequest>(_ request: T, completion: @escaping (Result<T.Response, APIClientError>) -> Void)
 }
 class APIClient: APIClientProtocol {
-    /// シングルトン
     static let shared = APIClient()
-
     private init() {}
 }
 // MARK: - API Base Method

--- a/iOSEngineerCodeCheck/Entity/APIClient.swift
+++ b/iOSEngineerCodeCheck/Entity/APIClient.swift
@@ -67,6 +67,7 @@ extension APIClient {
                 throw APIClientError.unknown
             }
             let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
             if (200..<300).contains(response.statusCode) {
                 do {
                     let apiResponse = try decoder.decode(T.Response.self, from: data)

--- a/iOSEngineerCodeCheck/Entity/APIClient.swift
+++ b/iOSEngineerCodeCheck/Entity/APIClient.swift
@@ -14,6 +14,8 @@ protocol APIClientProtocol {
     ///   - request: APIコール用のリクエスト
     ///   - completion: APIレスポンス取得の成功、失敗ハンドル
     func sendRequest<T: GitHubAPIRequest>(_ request: T, completion: @escaping (Result<T.Response, APIClientError>) -> Void)
+    @available(iOS 15.0, *)
+    func sendRequest<T: GitHubAPIRequest>(_ request: T) async throws -> T.Response
 }
 class APIClient: APIClientProtocol {
     static let shared = APIClient()
@@ -54,5 +56,34 @@ extension APIClient {
             }
         }
         task.resume()
+    }
+    
+    @available(iOS 15.0, *)
+    func sendRequest<T: GitHubAPIRequest>(_ request: T) async throws -> T.Response {
+        let session = URLSession.shared
+        do {
+            let (data, response) = try await session.data(for: request.buildURLRequest(), delegate: nil)
+            guard let response = response as? HTTPURLResponse else {
+                throw APIClientError.unknown
+            }
+            let decoder = JSONDecoder()
+            if (200..<300).contains(response.statusCode) {
+                do {
+                    let apiResponse = try decoder.decode(T.Response.self, from: data)
+                    return apiResponse
+                } catch {
+                    throw APIClientError.responseParseError(error)
+                }
+            } else {
+                do {
+                    let apiError = try decoder.decode(GitHubAPIError.self, from: data)
+                    throw apiError
+                } catch {
+                    throw APIClientError.responseParseError(error)
+                }
+            }
+        } catch {
+            throw APIClientError.unknown
+        }
     }
 }

--- a/iOSEngineerCodeCheck/Repository/GitHubRepositorySearchRepository.swift
+++ b/iOSEngineerCodeCheck/Repository/GitHubRepositorySearchRepository.swift
@@ -16,6 +16,8 @@ protocol GitHubRepositorySearchRepositoryProtocol {
     ///   - page: ページ番号
     ///   - completion: リポジトリ取得の成功、失敗ハンドル
     func getGitHubRepositorys(searchWord: String, searchCount: Int, page: Int, completion: @escaping (Result<Items<GitHubRepository>, APIClientError>) -> Void)
+    @available(iOS 15.0, *)
+    func async_getGitHubRepositorys(searchWord: String, serchCount: Int, page: Int, completion: @escaping (Result<Items<GitHubRepository>, Error>) -> Void)
 }
 class GitHubRepositorySearchRepository: GitHubRepositorySearchRepositoryProtocol {
 }
@@ -33,5 +35,18 @@ extension GitHubRepositorySearchRepository {
                 completion(.failure(error))
             }
         }
+    }
+    @available(iOS 15.0, *)
+    func async_getGitHubRepositorys(searchWord: String, serchCount: Int, page: Int, completion: @escaping (Result<Items<GitHubRepository>, Error>) -> Void) {
+        Task.detached {
+            do {
+                let gitHubAPIRequest = SearchRepositoriesRequest(searchWord: searchWord, searchCount: serchCount, page: page)
+                let response = try await APIClient.shared.sendRequest(gitHubAPIRequest)
+                completion(.success(response))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+        
     }
 }

--- a/iOSEngineerCodeCheck/ScreenModule/Search/GitHubRepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/ScreenModule/Search/GitHubRepositorySearchViewController.swift
@@ -71,7 +71,11 @@ extension GitHubRepositorySearchViewController {
         // APIコール
         self.viewModel.initAPIParameters()
         self.viewModel.searchWord = searchText
-        self.viewModel.getGitHubRepositorys()
+        if #available(iOS 15.0, *) {
+            self.viewModel.async_getGitHubRepositorys()
+        } else {
+            self.viewModel.getGitHubRepositorys()
+        }
     }
     // リポジトリがない場合の処理
     private func setNoRepository() {

--- a/iOSEngineerCodeCheck/ScreenModule/Search/GitHubRepositorySearchViewModel.swift
+++ b/iOSEngineerCodeCheck/ScreenModule/Search/GitHubRepositorySearchViewModel.swift
@@ -17,30 +17,25 @@ protocol GitHubRepositorySearchViewModelDelegate: AnyObject {
 }
 
 class GitHubRepositorySearchViewModel: NSObject {
-    /// GitHubRepositoryのリポジトリクラス
     private let gitHubRepositorySearchRepository: GitHubRepositorySearchRepositoryProtocol
-    /// GitHubのリポジトリ一覧
     var gitHubRepositorys: [GitHubRepository] = []
-    /// GitHubRepositorySearchViewModelのデリゲート
+
     weak var delegate: GitHubRepositorySearchViewModelDelegate?
-    /// GitHubリポジトリの検索結果最大取得数
+
     let maxGitHubRepositorySearchCount = 20
-    /// GitHubリポジトリの検索ページ番号
     var gitHubRepositorySearchPageNumber: Int = 1
-    /// APIの読み込み状況
     var apiLoadStatus: APILoadingStatus = .initial
-    /// 検索ワード
     var searchWord: String = ""
 
     init(gitHubRepositorySearchRepository: GitHubRepositorySearchRepositoryProtocol) {
         self.gitHubRepositorySearchRepository = gitHubRepositorySearchRepository
     }
 }
+
 // MARK: - API Method
+
 extension GitHubRepositorySearchViewModel {
-    /// GitHubRepositoryを取得する
     func getGitHubRepositorys() {
-        /// API読み込み状況
         if self.apiLoadStatus == .fetching || self.apiLoadStatus == .full {
             return
         } else {
@@ -62,14 +57,15 @@ extension GitHubRepositorySearchViewModel {
             }
         }
     }
-    /// APIのコールパラメータを初期化する
     func initAPIParameters() {
         self.gitHubRepositorySearchPageNumber = 1
         self.apiLoadStatus = .initial
         self.gitHubRepositorys = []
     }
 }
+
 // MARK: - UITableView DataSource Method
+
 extension GitHubRepositorySearchViewModel: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         self.gitHubRepositorys.count

--- a/iOSEngineerCodeCheck/ScreenModule/Search/GitHubRepositorySearchViewModel.swift
+++ b/iOSEngineerCodeCheck/ScreenModule/Search/GitHubRepositorySearchViewModel.swift
@@ -57,6 +57,29 @@ extension GitHubRepositorySearchViewModel {
             }
         }
     }
+    @available(iOS 15.0, *)
+    func async_getGitHubRepositorys() {
+        if self.apiLoadStatus == .fetching || self.apiLoadStatus == .full {
+            return
+        } else {
+            self.apiLoadStatus = .fetching
+        }
+        self.gitHubRepositorySearchRepository.async_getGitHubRepositorys(searchWord: searchWord, serchCount: maxGitHubRepositorySearchCount, page: gitHubRepositorySearchPageNumber) { response in
+            switch response {
+            case .success(let response):
+                if response.items.count < self.maxGitHubRepositorySearchCount {
+                    self.apiLoadStatus = .full
+                } else {
+                    self.apiLoadStatus = .initial
+                }
+                self.gitHubRepositorySearchPageNumber += 1
+                self.gitHubRepositorys.append(contentsOf: response.items)
+                self.delegate?.didSuccessGetGitHubRepositorys()
+            case .failure(let error):
+                self.delegate?.didFailedGetGitHubRepositorys(errorMessage: error.localizedDescription)
+            }
+        }
+    }
     func initAPIParameters() {
         self.gitHubRepositorySearchPageNumber = 1
         self.apiLoadStatus = .initial


### PR DESCRIPTION
## プルリクタイプ

<!-- タイプを選択、不要なものは都度消してください -->

- ✨ 新機能追加

## やったこと
- APIClient、GitHubRepositorySearchRepository、GitHubRepositorySearchVM、GitHubRepositorySearchVCにasync-awaitを使ったfetchメソッドを追加

<!-- 必須項目：issueのリンクを貼ったり、実装の概要を書いたりする -->

## 確認したこと
- 任意の検索ワードを使いAPI responseが正常に取得できること

<!-- 任意項目：テスト内容、実装したスクリーンショット、参考にしたサイト等を書いたりする -->

## 特記事項

特になし

<!-- 任意項目：実装上の懸念点、未改修の部分等を書いたりする -->
