### PR TITLE
Offline handler

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		9CF78B722D46148E00B579E3 /* APILoadingStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF78B712D46148E00B579E3 /* APILoadingStatus.swift */; };
 		9CF78B752D46204C00B579E3 /* NetworkConnectivityHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF78B742D46204C00B579E3 /* NetworkConnectivityHelper.swift */; };
 		9CF78B772D46319200B579E3 /* GitHubRepositorySearchErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF78B762D46319200B579E3 /* GitHubRepositorySearchErrorView.swift */; };
+		9CF88D242D4F68B3004E4176 /* GitHubSearchError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF88D232D4F68B3004E4176 /* GitHubSearchError.swift */; };
 		9CFF16E42D4DBD6500370371 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CFF16E32D4DBD6500370371 /* SceneDelegate.swift */; };
 		A45489064DF3F44EDFB862A2 /* Pods_iOSEngineerCodeCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FAC02F1CACFDD906B54C0DAB /* Pods_iOSEngineerCodeCheck.framework */; };
 		AD051E8423B433B52885F6F7 /* libPods-iOSEngineerCodeCheckTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F5143B5832E3B2B61CB07E4 /* libPods-iOSEngineerCodeCheckTests.a */; };
@@ -449,6 +450,7 @@
 		9CF78B712D46148E00B579E3 /* APILoadingStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APILoadingStatus.swift; sourceTree = "<group>"; };
 		9CF78B742D46204C00B579E3 /* NetworkConnectivityHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConnectivityHelper.swift; sourceTree = "<group>"; };
 		9CF78B762D46319200B579E3 /* GitHubRepositorySearchErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositorySearchErrorView.swift; sourceTree = "<group>"; };
+		9CF88D232D4F68B3004E4176 /* GitHubSearchError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearchError.swift; sourceTree = "<group>"; };
 		9CFF16E32D4DBD6500370371 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* GitHubRepositoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryDetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -601,6 +603,7 @@
 				BFD945E4244DC5E80012785A /* GitHubRepositorySearchViewController.storyboard */,
 				BFD945E2244DC5E80012785A /* GitHubRepositorySearchViewController.swift */,
 				9CF78B762D46319200B579E3 /* GitHubRepositorySearchErrorView.swift */,
+				9CF88D232D4F68B3004E4176 /* GitHubSearchError.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -1478,6 +1481,7 @@
 				9CF78B702D46142200B579E3 /* HTTPMethod.swift in Sources */,
 				9CD370F72571CAE7001759F8 /* GitHubRepository.swift in Sources */,
 				9CD370E12570D738001759F8 /* GitHubRepositorySearchBaseView.swift in Sources */,
+				9CF88D242D4F68B3004E4176 /* GitHubSearchError.swift in Sources */,
 				9CD370F22571C954001759F8 /* GitHubRepositorySearchRepository.swift in Sources */,
 				9C632DAE25BBEF3D00142A3D /* SearchRepositoriesRequest.swift in Sources */,
 				9CE200B62AD199E500932AE3 /* GraphQLRequestProtocol.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -63,7 +63,7 @@
 		9CF78B722D46148E00B579E3 /* APILoadingStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF78B712D46148E00B579E3 /* APILoadingStatus.swift */; };
 		9CF78B752D46204C00B579E3 /* NetworkConnectivityHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF78B742D46204C00B579E3 /* NetworkConnectivityHelper.swift */; };
 		9CF78B772D46319200B579E3 /* GitHubRepositorySearchErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF78B762D46319200B579E3 /* GitHubRepositorySearchErrorView.swift */; };
-		9CF88D242D4F68B3004E4176 /* GitHubSearchError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF88D232D4F68B3004E4176 /* GitHubSearchError.swift */; };
+		9CF88D242D4F68B3004E4176 /* GitHubSearchErrorState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF88D232D4F68B3004E4176 /* GitHubSearchErrorState.swift */; };
 		9CFF16E42D4DBD6500370371 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CFF16E32D4DBD6500370371 /* SceneDelegate.swift */; };
 		A45489064DF3F44EDFB862A2 /* Pods_iOSEngineerCodeCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FAC02F1CACFDD906B54C0DAB /* Pods_iOSEngineerCodeCheck.framework */; };
 		AD051E8423B433B52885F6F7 /* libPods-iOSEngineerCodeCheckTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F5143B5832E3B2B61CB07E4 /* libPods-iOSEngineerCodeCheckTests.a */; };
@@ -450,7 +450,7 @@
 		9CF78B712D46148E00B579E3 /* APILoadingStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APILoadingStatus.swift; sourceTree = "<group>"; };
 		9CF78B742D46204C00B579E3 /* NetworkConnectivityHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConnectivityHelper.swift; sourceTree = "<group>"; };
 		9CF78B762D46319200B579E3 /* GitHubRepositorySearchErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositorySearchErrorView.swift; sourceTree = "<group>"; };
-		9CF88D232D4F68B3004E4176 /* GitHubSearchError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearchError.swift; sourceTree = "<group>"; };
+		9CF88D232D4F68B3004E4176 /* GitHubSearchErrorState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearchErrorState.swift; sourceTree = "<group>"; };
 		9CFF16E32D4DBD6500370371 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* GitHubRepositoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryDetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -603,7 +603,7 @@
 				BFD945E4244DC5E80012785A /* GitHubRepositorySearchViewController.storyboard */,
 				BFD945E2244DC5E80012785A /* GitHubRepositorySearchViewController.swift */,
 				9CF78B762D46319200B579E3 /* GitHubRepositorySearchErrorView.swift */,
-				9CF88D232D4F68B3004E4176 /* GitHubSearchError.swift */,
+				9CF88D232D4F68B3004E4176 /* GitHubSearchErrorState.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -1481,7 +1481,7 @@
 				9CF78B702D46142200B579E3 /* HTTPMethod.swift in Sources */,
 				9CD370F72571CAE7001759F8 /* GitHubRepository.swift in Sources */,
 				9CD370E12570D738001759F8 /* GitHubRepositorySearchBaseView.swift in Sources */,
-				9CF88D242D4F68B3004E4176 /* GitHubSearchError.swift in Sources */,
+				9CF88D242D4F68B3004E4176 /* GitHubSearchErrorState.swift in Sources */,
 				9CD370F22571C954001759F8 /* GitHubRepositorySearchRepository.swift in Sources */,
 				9C632DAE25BBEF3D00142A3D /* SearchRepositoriesRequest.swift in Sources */,
 				9CE200B62AD199E500932AE3 /* GraphQLRequestProtocol.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		9CE200BA2AD19FC300932AE3 /* GraphQLSearchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE200B92AD19FC300932AE3 /* GraphQLSearchRequest.swift */; };
 		9CE200BC2AD1A0C600932AE3 /* github-access-token.json in Resources */ = {isa = PBXBuildFile; fileRef = 9CE200BB2AD1A0C600932AE3 /* github-access-token.json */; };
 		9CE200BE2AD1A19F00932AE3 /* JsonFileReadHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE200BD2AD1A19F00932AE3 /* JsonFileReadHelper.swift */; };
+		9CEF9C0F2D4E01C600FB65AC /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEF9C0E2D4E01C600FB65AC /* Logger.swift */; };
 		9CF78B702D46142200B579E3 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF78B6F2D46142200B579E3 /* HTTPMethod.swift */; };
 		9CF78B722D46148E00B579E3 /* APILoadingStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF78B712D46148E00B579E3 /* APILoadingStatus.swift */; };
 		9CF78B752D46204C00B579E3 /* NetworkConnectivityHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF78B742D46204C00B579E3 /* NetworkConnectivityHelper.swift */; };
@@ -443,6 +444,7 @@
 		9CE2FE562AD1978F00932AE3 /* Lockable.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lockable.graphql.swift; sourceTree = "<group>"; };
 		9CE2FE572AD1978F00932AE3 /* ProfileOwner.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileOwner.graphql.swift; sourceTree = "<group>"; };
 		9CE2FE582AD1978F00932AE3 /* GitHubGraphQL.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubGraphQL.graphql.swift; sourceTree = "<group>"; };
+		9CEF9C0E2D4E01C600FB65AC /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		9CF78B6F2D46142200B579E3 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		9CF78B712D46148E00B579E3 /* APILoadingStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APILoadingStatus.swift; sourceTree = "<group>"; };
 		9CF78B742D46204C00B579E3 /* NetworkConnectivityHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConnectivityHelper.swift; sourceTree = "<group>"; };
@@ -586,6 +588,7 @@
 				9CD370FE2571E251001759F8 /* Static */,
 				9C8D9B4525BE9516006AC01F /* Helper */,
 				9C7B98B3257357C200D2521B /* Extension */,
+				9CEF9C0E2D4E01C600FB65AC /* Logger.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -1496,6 +1499,7 @@
 				9C9AD53225C961560036352A /* GitHubReadme.swift in Sources */,
 				9CF78B722D46148E00B579E3 /* APILoadingStatus.swift in Sources */,
 				9CFF16E42D4DBD6500370371 /* SceneDelegate.swift in Sources */,
+				9CEF9C0F2D4E01C600FB65AC /* Logger.swift in Sources */,
 				9C88CFC225C28BBB001D4AB3 /* GitHubLicenseBaseView.swift in Sources */,
 				9C8E168625BEE5DB005CC118 /* UIColor+Extension.swift in Sources */,
 				9C950C4C25C37C2D001BC95B /* MainSplitViewController.swift in Sources */,

--- a/iOSEngineerCodeCheck/AppDelegate.swift
+++ b/iOSEngineerCodeCheck/AppDelegate.swift
@@ -14,19 +14,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        print("--- アプリ起動 ---")
-        
+        kLogger.debugPrint("アプリ起動")
+
         NetworkConnectivity.shared.setup()
-        print("DEBUG: isOnline=\(NetworkConnectivity.shared.isOnline)")
+        kLogger.debugPrint("isOnline=\(NetworkConnectivity.shared.isOnline)")
         return true
     }
 
     // MARK: - UISceneSession Lifecycle
-    
+
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
-        print("--- Scene呼び出し ---")
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 

--- a/iOSEngineerCodeCheck/AppDelegate.swift
+++ b/iOSEngineerCodeCheck/AppDelegate.swift
@@ -34,7 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-        print("--- アプリ停止 ---")
+        kLogger.debugPrint("--- アプリ停止 ---")
     }
     */
 }

--- a/iOSEngineerCodeCheck/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/iOSEngineerCodeCheck/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,1 +1,284 @@
-{"images":[{"size":"60x60","expected-size":"180","filename":"180.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"3x"},{"size":"40x40","expected-size":"80","filename":"80.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"2x"},{"size":"40x40","expected-size":"120","filename":"120.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"3x"},{"size":"60x60","expected-size":"120","filename":"120.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"2x"},{"size":"57x57","expected-size":"57","filename":"57.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"1x"},{"size":"29x29","expected-size":"58","filename":"58.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"2x"},{"size":"29x29","expected-size":"29","filename":"29.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"1x"},{"size":"29x29","expected-size":"87","filename":"87.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"3x"},{"size":"57x57","expected-size":"114","filename":"114.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"2x"},{"size":"20x20","expected-size":"40","filename":"40.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"2x"},{"size":"20x20","expected-size":"60","filename":"60.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"3x"},{"size":"1024x1024","filename":"1024.png","expected-size":"1024","idiom":"ios-marketing","folder":"Assets.xcassets/AppIcon.appiconset/","scale":"1x"},{"size":"40x40","expected-size":"80","filename":"80.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"2x"},{"size":"72x72","expected-size":"72","filename":"72.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"1x"},{"size":"76x76","expected-size":"152","filename":"152.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"2x"},{"size":"50x50","expected-size":"100","filename":"100.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"2x"},{"size":"29x29","expected-size":"58","filename":"58.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"2x"},{"size":"76x76","expected-size":"76","filename":"76.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"1x"},{"size":"29x29","expected-size":"29","filename":"29.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"1x"},{"size":"50x50","expected-size":"50","filename":"50.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"1x"},{"size":"72x72","expected-size":"144","filename":"144.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"2x"},{"size":"40x40","expected-size":"40","filename":"40.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"1x"},{"size":"83.5x83.5","expected-size":"167","filename":"167.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"2x"},{"size":"20x20","expected-size":"20","filename":"20.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"1x"},{"size":"20x20","expected-size":"40","filename":"40.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"2x"},{"idiom":"watch","filename":"172.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"38mm","scale":"2x","size":"86x86","expected-size":"172","role":"quickLook"},{"idiom":"watch","filename":"80.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"38mm","scale":"2x","size":"40x40","expected-size":"80","role":"appLauncher"},{"idiom":"watch","filename":"88.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"40mm","scale":"2x","size":"44x44","expected-size":"88","role":"appLauncher"},{"idiom":"watch","filename":"100.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"44mm","scale":"2x","size":"50x50","expected-size":"100","role":"appLauncher"},{"idiom":"watch","filename":"196.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"42mm","scale":"2x","size":"98x98","expected-size":"196","role":"quickLook"},{"idiom":"watch","filename":"216.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"44mm","scale":"2x","size":"108x108","expected-size":"216","role":"quickLook"},{"idiom":"watch","filename":"48.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"38mm","scale":"2x","size":"24x24","expected-size":"48","role":"notificationCenter"},{"idiom":"watch","filename":"55.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"42mm","scale":"2x","size":"27.5x27.5","expected-size":"55","role":"notificationCenter"},{"size":"29x29","expected-size":"87","filename":"87.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"watch","role":"companionSettings","scale":"3x"},{"size":"29x29","expected-size":"58","filename":"58.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"watch","role":"companionSettings","scale":"2x"},{"size":"1024x1024","expected-size":"1024","filename":"1024.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"watch-marketing","scale":"1x"}]}
+{
+  "images" : [
+    {
+      "filename" : "40.png",
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "filename" : "60.png",
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "filename" : "29.png",
+      "idiom" : "iphone",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "58.png",
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "87.png",
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "80.png",
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "filename" : "120.png",
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "filename" : "57.png",
+      "idiom" : "iphone",
+      "scale" : "1x",
+      "size" : "57x57"
+    },
+    {
+      "filename" : "114.png",
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "57x57"
+    },
+    {
+      "filename" : "120.png",
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "filename" : "180.png",
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "filename" : "20.png",
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "filename" : "40.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "filename" : "29.png",
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "58.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "40.png",
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "filename" : "80.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "filename" : "50.png",
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "50x50"
+    },
+    {
+      "filename" : "100.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "50x50"
+    },
+    {
+      "filename" : "72.png",
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "72x72"
+    },
+    {
+      "filename" : "144.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "72x72"
+    },
+    {
+      "filename" : "76.png",
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "filename" : "152.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "filename" : "167.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "filename" : "1024.png",
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    },
+    {
+      "filename" : "48.png",
+      "idiom" : "watch",
+      "role" : "notificationCenter",
+      "scale" : "2x",
+      "size" : "24x24",
+      "subtype" : "38mm"
+    },
+    {
+      "filename" : "55.png",
+      "idiom" : "watch",
+      "role" : "notificationCenter",
+      "scale" : "2x",
+      "size" : "27.5x27.5",
+      "subtype" : "42mm"
+    },
+    {
+      "filename" : "58.png",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "87.png",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "notificationCenter",
+      "scale" : "2x",
+      "size" : "33x33",
+      "subtype" : "45mm"
+    },
+    {
+      "filename" : "80.png",
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "40x40",
+      "subtype" : "38mm"
+    },
+    {
+      "filename" : "88.png",
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "44x44",
+      "subtype" : "40mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "46x46",
+      "subtype" : "41mm"
+    },
+    {
+      "filename" : "100.png",
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "50x50",
+      "subtype" : "44mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "51x51",
+      "subtype" : "45mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "54x54",
+      "subtype" : "49mm"
+    },
+    {
+      "filename" : "172.png",
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "86x86",
+      "subtype" : "38mm"
+    },
+    {
+      "filename" : "196.png",
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "98x98",
+      "subtype" : "42mm"
+    },
+    {
+      "filename" : "216.png",
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "108x108",
+      "subtype" : "44mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "117x117",
+      "subtype" : "45mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "129x129",
+      "subtype" : "49mm"
+    },
+    {
+      "filename" : "1024.png",
+      "idiom" : "watch-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOSEngineerCodeCheck/Data/Infrastructure/RestApi/APIClient.swift
+++ b/iOSEngineerCodeCheck/Data/Infrastructure/RestApi/APIClient.swift
@@ -29,8 +29,8 @@ extension APIClient {
                 completion(.failure(.unknown))
                 return
             }
-            //debugPrint("DEBUG: status=\(response.statusCode)\n", response)
-            //debugPrint("DEBUG: data=\(String(data: data, encoding: .utf8))")
+            kLogger.debugPrint("status=\(response.statusCode)\n", response)
+            kLogger.debugPrint("data=\(String(data: data, encoding: .utf8))")
             let decoder = JSONDecoder()
             // TODO: dateのフォーマット型はレスポンスによるのでデコーダー処理を別に定義した方が良さそう（ex. APIRequest型に実装する）
             decoder.dateDecodingStrategy = .iso8601

--- a/iOSEngineerCodeCheck/Store/Middleware/RepositoryMiddleware.swift
+++ b/iOSEngineerCodeCheck/Store/Middleware/RepositoryMiddleware.swift
@@ -17,7 +17,7 @@ func repositoryMiddleware() -> Middleware<AppState> {
                 case .success(let repository):
                     dispatch(SetRepositories(repositories: repository.items))
                 case .failure(let error):
-                    print(error.description())
+                    kLogger.debugPrint(error.description())
                 }
             }
         case let fetchAction as FetchRepositoryReadme:
@@ -26,7 +26,7 @@ func repositoryMiddleware() -> Middleware<AppState> {
                 case .success(let readme):
                     dispatch(SetRepositoryReadme(readme: readme))
                 case .failure(let error):
-                    print(error.description())
+                    kLogger.debugPrint(error.description())
                 }
             }
         case let fetchAction as FetchRepositoryLicense:
@@ -35,7 +35,7 @@ func repositoryMiddleware() -> Middleware<AppState> {
                 case .success(let license):
                     dispatch(SetRepositoryLicense(license: license))
                 case .failure(let error):
-                    print(error.description())
+                    kLogger.debugPrint(error.description())
                 }
             }
         default:

--- a/iOSEngineerCodeCheck/Utility/Extension/UIAlertController+Extension.swift
+++ b/iOSEngineerCodeCheck/Utility/Extension/UIAlertController+Extension.swift
@@ -12,12 +12,12 @@ extension UIAlertController {
     static func showAlert(style: UIAlertController.Style, viewController: UIViewController, title: String?, message: String?, okButtonTitle: String?, cancelButtonTitle: String?) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: style)
         let okAction = UIAlertAction(title: okButtonTitle, style: .default) { _ in
-            print("DEBUG: OKボタンが押されました")
+            kLogger.debugPrint("OKボタンが押されました")
         }
         alert.addAction(okAction)
         if let cancelButtonTitle = cancelButtonTitle {
             let cancelAction = UIAlertAction(title: cancelButtonTitle, style: .cancel) { _ in
-                print("DEEBUG: キャンセルボタンが押されました")
+                kLogger.debugPrint("キャンセルボタンが押されました")
             }
             alert.addAction(cancelAction)
         }

--- a/iOSEngineerCodeCheck/Utility/Extension/UIImage+Extension.swift
+++ b/iOSEngineerCodeCheck/Utility/Extension/UIImage+Extension.swift
@@ -14,12 +14,12 @@ extension UIImageView {
     ///   - imageUrlString: 画像URL
     func getImage(imageUrlString: String) {
         guard let url = URL(string: imageUrlString) else {
-            print("画像URLの変換に失敗しました")
+            kLogger.debugPrint("画像URLの変換に失敗しました")
             return
         }
         URLSession.shared.dataTask(with: url) { data, _, error in
             if let error = error {
-                print("画像の読み込みに失敗しました" + "DEBUG: error=\(error)")
+                kLogger.debugPrint("画像の読み込みに失敗しました \(error)")
                 return
             }
             guard let data = data else { return }

--- a/iOSEngineerCodeCheck/Utility/Helper/NetworkConnectivityHelper.swift
+++ b/iOSEngineerCodeCheck/Utility/Helper/NetworkConnectivityHelper.swift
@@ -11,18 +11,42 @@ import Network
 
 final class NetworkConnectivity {
     static let shared = NetworkConnectivity()
-    
+
     private let monitor: NWPathMonitor
-    
+    private var isFirstSetup = true
+
     var isOnline: Bool {
         monitor.currentPath.status == .satisfied
     }
-    
+
     private init() {
-        self.monitor = NWPathMonitor()
+        monitor = NWPathMonitor()
     }
-    
+
+    deinit {
+        monitor.cancel()
+    }
+
     func setup() {
-        monitor.start(queue: .global(qos: .background))
+        kLogger.debugPrint()
+
+        let semaphore = DispatchSemaphore(value: 0)
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self else {
+                return
+            }
+            if self.isFirstSetup {
+                kLogger.debugPrint("update network status=\(path.status)")
+                self.isFirstSetup = false
+                semaphore.signal()
+            }
+        }
+        monitor.start(queue: .global())
+        switch semaphore.wait(timeout: .now() + 1) {
+        case .success:
+            kLogger.debugPrint("success")
+        case .timedOut:
+            isFirstSetup = false
+        }
     }
 }

--- a/iOSEngineerCodeCheck/Utility/Logger.swift
+++ b/iOSEngineerCodeCheck/Utility/Logger.swift
@@ -7,3 +7,33 @@
 //
 
 import Foundation
+
+let kLogger = Logger()
+
+class Logger {
+    private let dateFormatter: DateFormatter
+    private var timeStamp: String {
+        dateFormatter.string(from: Date())
+    }
+
+    init() {
+        dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "HH:mm:ss.SSS"
+        dateFormatter.locale = Locale(identifier: "ja_JP")
+    }
+
+    func debugPrint(filePath: String = #file, function: String = #function, line: Int = #line, _ message: String = "") {
+        basePrint(filePath: filePath, function: function, line: line, message)
+    }
+
+    private func basePrint(filePath: String, function: String, line: Int, _ message: String) {
+        #if DEBUG
+        print("debug: \(className(from: filePath)) \(function) \(line) \(message)")
+        #endif
+    }
+
+    private func className(from filepath: String) -> String {
+        let fileName = filepath.components(separatedBy: "/").last
+        return fileName?.components(separatedBy: ".").first ?? ""
+    }
+}

--- a/iOSEngineerCodeCheck/Utility/Logger.swift
+++ b/iOSEngineerCodeCheck/Utility/Logger.swift
@@ -28,7 +28,7 @@ class Logger {
 
     private func basePrint(filePath: String, function: String, line: Int, _ message: String) {
         #if DEBUG
-        print("debug: \(className(from: filePath)) \(function) \(line) \(message)")
+        print("debug: \(timeStamp) \(className(from: filePath)) \(function) \(line) \(message)")
         #endif
     }
 

--- a/iOSEngineerCodeCheck/Utility/Logger.swift
+++ b/iOSEngineerCodeCheck/Utility/Logger.swift
@@ -1,0 +1,9 @@
+//
+//  Logger.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Shusuke Ota on 2025/2/1.
+//  Copyright © 2025 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation

--- a/iOSEngineerCodeCheck/View/Search/GitHubRepositorySearchBaseView.swift
+++ b/iOSEngineerCodeCheck/View/Search/GitHubRepositorySearchBaseView.swift
@@ -31,20 +31,20 @@ extension GitHubRepositorySearchBaseView {
         // リポジトリ検索結果の表示
         self.searchErrorView.isHidden = false
         self.searchErrorView.delegate = self
-        self.searchErrorView.updateDescription(text: "リポジトリーがないよー")
+        self.searchErrorView.updateErrorState(.ready)
     }
     func setNoRepositoryUI(gitHubRepositorys: [GitHubRepository]) {
         if !NetworkConnectivity.shared.isOnline {
             enabledSearchBar(enabled: false)
-            searchErrorView.updateDescription(text: "ネットワークに接続されていません")
+            searchErrorView.updateErrorState(.noNetwork)
             return
         }
         if gitHubRepositorys.isEmpty {
             searchErrorView.isHidden = false
-            searchErrorView.updateDescription(text: "リポジトリーがないよー")
+            searchErrorView.updateErrorState(.noRepositories)
         } else {
             searchErrorView.isHidden = true
-            searchErrorView.updateDescription(text: "")
+            searchErrorView.updateErrorState(.ready)
         }
         enabledSearchBar(enabled: true)
     }

--- a/iOSEngineerCodeCheck/View/Search/GitHubRepositorySearchErrorView.swift
+++ b/iOSEngineerCodeCheck/View/Search/GitHubRepositorySearchErrorView.swift
@@ -26,8 +26,9 @@ class GitHubRepositorySearchErrorView: UIView {
         setupAction()
     }
 
-    func updateDescription(text: String) {
-        descriptionLabel.text = text
+    func updateErrorState(_ error: GitHubSearchError) {
+        descriptionLabel.text = error.description
+        retryButton.isHidden = error.retryButtonIsHidden
     }
 
     private func setupComponent() {

--- a/iOSEngineerCodeCheck/View/Search/GitHubRepositorySearchErrorView.swift
+++ b/iOSEngineerCodeCheck/View/Search/GitHubRepositorySearchErrorView.swift
@@ -26,7 +26,7 @@ class GitHubRepositorySearchErrorView: UIView {
         setupAction()
     }
 
-    func updateErrorState(_ error: GitHubSearchError) {
+    func updateErrorState(_ error: GitHubSearchErrorState) {
         descriptionLabel.text = error.description
         retryButton.isHidden = error.retryButtonIsHidden
     }

--- a/iOSEngineerCodeCheck/View/Search/GitHubRepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/View/Search/GitHubRepositorySearchViewController.swift
@@ -135,11 +135,11 @@ extension GitHubRepositorySearchViewController {
                 if let optionalNodes = response?.search.nodes {
                     let nodes = optionalNodes.compactMap { $0 }
                     nodes.forEach { node in
-                        print("DEBUG: repository_name=\(String(describing: node.asRepository?.nameWithOwner))")
+                        kLogger.debugPrint("repository_name=\(String(describing: node.asRepository?.nameWithOwner))")
                     }
                 }
             case .failure(let error):
-                print("DEBUG: \(error.localizedDescription)")
+                kLogger.debugPrint("\(error.localizedDescription)")
             }
         }
     }

--- a/iOSEngineerCodeCheck/View/Search/GitHubSearchError.swift
+++ b/iOSEngineerCodeCheck/View/Search/GitHubSearchError.swift
@@ -1,0 +1,37 @@
+//
+//  GitHubSearchError.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Shusuke Ota on 2025/2/2.
+//  Copyright © 2025 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+enum GitHubSearchError {
+    case ready
+    case noRepositories
+    case noNetwork
+
+    var description: String {
+        switch self {
+        case  .ready:
+            return ""
+        case .noRepositories:
+            return "リポジトリーがないよー"
+        case .noNetwork:
+            return "ネットワークに接続されていません"
+        }
+    }
+
+    var retryButtonIsHidden: Bool {
+        switch self {
+        case .ready:
+            return true
+        case .noRepositories:
+            return true
+        case .noNetwork:
+            return false
+        }
+    }
+}

--- a/iOSEngineerCodeCheck/View/Search/GitHubSearchErrorState.swift
+++ b/iOSEngineerCodeCheck/View/Search/GitHubSearchErrorState.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum GitHubSearchError {
+enum GitHubSearchErrorState {
     case ready
     case noRepositories
     case noNetwork


### PR DESCRIPTION
## プルリクタイプ
<!-- タイプを選択、不要なものは都度消してください -->
- 🔧 改善

## やったこと
<!-- 必須項目：issueのリンクを貼ったり、実装の概要を書いたりする -->
- Loggerを追加
- GitHubSearchErrorStateを追加し、ErrorStateによってSearchErrorViewを更新するようにした
- NetworkConnectivity.setup後、currentPath.statusが更新された後に`isOnline`を参照するようにした
  - 理由
  - monitor.start実行後、端末やiOSバージョンによってstatusが更新されるまでラグが発生することがある
  - statusが更新される前に`isOnline`を参照してViewの更新を行うとネットワークの接続が確立されているのにも関わらずstatus == .unsatisfiedと判定されてしまうことがある
  - そのため、初回（monitor.start直後）はstatusの更新が終わるまで処理を待つようにした
  - また、デッドロック回避のためtimeoutも設定。statusが更新されるラグはiPhone6s iOS15.5で確認した限り500ms（他の最新端末は数ms）であるためtimeoutは1sとした。

## 確認したこと
<!-- 任意項目：テスト内容、実装したスクリーンショット、参考にしたサイト等を書いたりする -->

省略

## 特記事項
<!-- 任意項目：実装上の懸念点、未改修の部分等を書いたりする -->

なし